### PR TITLE
Add examples to rustdoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,6 @@ jobs:
         shell: bash
         run: cargo test --workspace
         
+      - name: Validate docs examples
+        shell: bash
+        run: cargo test --doc

--- a/src/key_value.rs
+++ b/src/key_value.rs
@@ -3,6 +3,18 @@
 //! This module provides a generic interface for key-value storage, which may be implemented by the host various
 //! ways (e.g. via an in-memory table, a local file, or a remote database). Details such as consistency model and
 //! durability will depend on the implementation and may vary from one to store to the next.
+//!
+//! # Examples
+//!
+//! Open the default store and set the 'message' key:
+//!
+//! ```no_run
+//! # fn main() -> anyhow::Result<()> {
+//! let store = spin_sdk::key_value::Store::open_default()?;
+//! store.set("message", "Hello world".as_bytes())?;
+//! # Ok(())
+//! # }
+//! ```
 
 use super::wit::v2::key_value;
 
@@ -10,7 +22,54 @@ use super::wit::v2::key_value;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[doc(inline)]
-pub use key_value::{Error, Store};
+pub use key_value::Error;
+
+/// An open key-value store.
+///
+/// # Examples
+///
+/// Open the default store and set the 'message' key:
+///
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// let store = spin_sdk::key_value::Store::open_default()?;
+/// store.set("message", "Hello world".as_bytes())?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Open the default store and get the 'message' key:
+///
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// let store = spin_sdk::key_value::Store::open_default()?;
+/// let message = store.get("message")?;
+/// let response = message.unwrap_or_else(|| "not found".into());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Open a named store and list all the keys defined in it:
+///
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// let store = spin_sdk::key_value::Store::open("finance")?;
+/// let keys = store.get_keys()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Open the default store and delete the 'message' key:
+///
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// let store = spin_sdk::key_value::Store::open_default()?;
+/// store.delete("message")?;
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use key_value::Store;
 
 impl Store {
     /// Open the default store.
@@ -24,6 +83,31 @@ impl Store {
 impl Store {
     #[cfg(feature = "json")]
     /// Serialize the given data to JSON, then set it as the value for the specified `key`.
+    ///
+    /// # Examples
+    ///
+    /// Open the default store and save a customer information document against the customer ID:
+    ///
+    /// ```no_run
+    /// # use serde::{Deserialize, Serialize};
+    /// #[derive(Deserialize, Serialize)]
+    /// struct Customer {
+    ///     name: String,
+    ///     address: Vec<String>,
+    /// }
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let customer_id = "CR1234567";
+    /// let customer = Customer {
+    ///     name: "Alice".to_owned(),
+    ///     address: vec!["Wonderland Way".to_owned()],
+    /// };
+    ///
+    /// let store = spin_sdk::key_value::Store::open_default()?;
+    /// store.set_json(customer_id, &customer)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_json<T: Serialize>(
         &self,
         key: impl AsRef<str>,
@@ -34,6 +118,27 @@ impl Store {
 
     #[cfg(feature = "json")]
     /// Deserialize an instance of type `T` from the value of `key`.
+    ///
+    /// # Examples
+    ///
+    /// Open the default store and retrieve a customer information document by customer ID:
+    ///
+    /// ```no_run
+    /// # use serde::{Deserialize, Serialize};
+    /// #[derive(Deserialize, Serialize)]
+    /// struct Customer {
+    ///     name: String,
+    ///     address: Vec<String>,
+    /// }
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let customer_id = "CR1234567";
+    ///
+    /// let store = spin_sdk::key_value::Store::open_default()?;
+    /// let customer = store.get_json::<Customer>(customer_id)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get_json<T: DeserializeOwned>(
         &self,
         key: impl AsRef<str>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod key_value;
 /// SQLite storage.
 pub mod sqlite;
 
-/// Large Language Model APIs
+/// Large Language Model (Serverless AI) APIs
 pub mod llm;
 
 /// Exports the procedural macros for writing handlers for Spin components.
@@ -57,13 +57,13 @@ extern "C" fn __spin_sdk_hash() {}
 /// Helpers for building Spin `wasi-http` components.
 pub mod http;
 
-/// Implementation of the spin mqtt interface.
+/// MQTT messaging.
 #[allow(missing_docs)]
 pub mod mqtt {
     pub use super::wit::v2::mqtt::{Connection, Error, Payload, Qos};
 }
 
-/// Implementation of the spin redis interface.
+/// Redis storage and messaging.
 #[allow(missing_docs)]
 pub mod redis {
     use std::hash::{Hash, Hasher};
@@ -99,16 +99,18 @@ pub mod redis {
     }
 }
 
-/// Implementation of the spin postgres db interface.
+/// Spin 2 Postgres relational database storage. Applications that do not require
+/// Spin 2 support should use the `pg3` module instead.
 pub mod pg;
 
-/// Implementation of the spin postgres v3 db interface.
+/// Postgres relational database storage.
 pub mod pg3;
 
-/// Implementation of the Spin MySQL database interface.
+/// MySQL relational database storage.
 pub mod mysql;
 
 #[doc(inline)]
+/// Component configuration variables.
 pub use wit::v2::variables;
 
 #[doc(hidden)]

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,7 +1,49 @@
-pub use crate::wit::v2::llm::{
-    self, EmbeddingsResult, EmbeddingsUsage, Error, InferencingParams, InferencingResult,
-    InferencingUsage,
-};
+pub use crate::wit::v2::llm::{Error, InferencingParams, InferencingResult, InferencingUsage};
+
+/// Provides access to the underlying WIT interface. You should not normally need
+/// to use this module: use the re-exports in this module instead.
+#[doc(inline)]
+pub use crate::wit::v2::llm;
+
+/// The result of generating embeddings.
+///
+/// # Examples
+///
+/// Generate embeddings using the all-minilm-l6-v2 LLM.
+///
+/// ```no_run
+/// use spin_sdk::llm;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let text = &[
+///     "I've just broken a priceless turnip".to_owned(),
+/// ];
+///
+/// let embed_result = llm::generate_embeddings(llm::EmbeddingModel::AllMiniLmL6V2, text)?;
+///
+/// println!("prompt token count: {}", embed_result.usage.prompt_token_count);
+/// println!("embedding: {:?}", embed_result.embeddings.first());
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use crate::wit::v2::llm::EmbeddingsResult;
+
+/// Usage related to an embeddings generation request.
+///
+/// # Examples
+///
+/// ```no_run
+/// use spin_sdk::llm;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let text = &[];
+/// let embed_result = llm::generate_embeddings(llm::EmbeddingModel::AllMiniLmL6V2, text)?;
+/// println!("prompt token count: {}", embed_result.usage.prompt_token_count);
+/// # Ok(())
+/// # }
+/// ```
+pub use crate::wit::v2::llm::EmbeddingsUsage;
 
 /// The model use for inferencing
 #[allow(missing_docs)]

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,7 +1,186 @@
 use super::wit::v2::sqlite;
 
 #[doc(inline)]
-pub use sqlite::{Connection, Error, QueryResult, RowResult, Value};
+pub use sqlite::{Error, Value};
+
+/// An open connection to a SQLite database.
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Use the [QueryResult::rows()] wrapper to access a column by name. This is simpler and
+/// more readable but incurs a lookup on each access, so is not recommended when
+/// iterating a data set.
+///
+/// ```no_run
+/// # use spin_sdk::sqlite::{Connection, Value};
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open_default()?;
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE id = ?",
+///     &[Value::Integer(user_id)]
+/// )?;
+/// let name = query_result.rows().next().and_then(|r| r.get::<&str>("name")).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Perform an aggregate (scalar) operation over a named SQLite database. The result
+/// set contains a single column, with a single row.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::Connection;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open("customer-data")?;
+/// let query_result = db.execute("SELECT COUNT(*) FROM users", &[])?;
+/// let count = query_result.rows.first().and_then(|r| r.get::<usize>(0)).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Delete rows from a SQLite database. The usual [Connection::execute()] syntax
+/// is used but the query result is always empty.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 18;
+/// let db = Connection::open("customer-data")?;
+/// db.execute("DELETE FROM users WHERE age < ?", &[Value::Integer(min_age)])?;
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use sqlite::Connection;
+
+/// The result of a SQLite query issued with [Connection::execute()].
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Use the [QueryResult::rows()] wrapper to access a column by name. This is simpler and
+/// more readable but incurs a lookup on each access, so is not recommended when
+/// iterating a data set.
+///
+/// ```no_run
+/// # use spin_sdk::sqlite::{Connection, Value};
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open_default()?;
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE id = ?",
+///     &[Value::Integer(user_id)]
+/// )?;
+/// let name = query_result.rows().next().and_then(|r| r.get::<&str>("name")).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Perform an aggregate (scalar) operation over a named SQLite database. The result
+/// set contains a single column, with a single row.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::Connection;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open("customer-data")?;
+/// let query_result = db.execute("SELECT COUNT(*) FROM users", &[])?;
+/// let count = query_result.rows.first().and_then(|r| r.get::<usize>(0)).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use sqlite::QueryResult;
+
+/// A database row result.
+///
+/// There are two representations of a SQLite row in the SDK. This type is obtained from
+/// the [field@QueryResult::rows] field, and provides index-based lookup or low-level access
+/// to row values via a vector. The [Row] type is useful for
+/// addressing elements by column name, and is obtained from the [QueryResult::rows()] function.
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them selecting one
+/// field from each. The example caches the index of the desired field to avoid repeated lookup,
+/// making this more efficient than the [Row]-based equivalent at the expense of
+/// extra code and inferior readability.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+
+#[doc(inline)]
+pub use sqlite::RowResult;
 
 impl sqlite::Connection {
     /// Open a connection to the default database
@@ -20,14 +199,47 @@ impl sqlite::QueryResult {
     }
 }
 
-/// A database row result
+/// A database row result.
+///
+/// There are two representations of a SQLite row in the SDK.  This type is useful for
+/// addressing elements by column name, and is obtained from the [QueryResult::rows()] function.
+/// The [RowResult] type is obtained from the [field@QueryResult::rows] field, and provides
+/// index-based lookup or low-level access to row values via a vector.
 pub struct Row<'a> {
     columns: &'a [String],
     result: &'a sqlite::RowResult,
 }
 
 impl<'a> Row<'a> {
-    /// Get a value by its column name
+    /// Get a value by its column name. The value is converted to the target type.
+    ///
+    /// * SQLite integers are convertible to Rust integer types (i8, u8, i16, etc. including usize and isize) and bool.
+    /// * SQLite strings are convertible to Rust &str or &[u8] (encoded as UTF-8).
+    /// * SQLite reals are convertible to Rust f64.
+    /// * SQLite blobs are convertible to Rust &[u8] or &str (interpreted as UTF-8).
+    ///
+    /// If your code does not know the type in advance, use [RowResult] instead of `Row` to
+    /// access the underlying [Value] enum.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spin_sdk::sqlite::{Connection, Value};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let user_id = 0;
+    /// let db = Connection::open_default()?;
+    /// let query_result = db.execute(
+    ///     "SELECT * FROM users WHERE id = ?",
+    ///     &[Value::Integer(user_id)]
+    /// )?;
+    /// let user_row = query_result.rows().next().unwrap();
+    ///
+    /// let name = user_row.get::<&str>("name").unwrap();
+    /// let age = user_row.get::<u16>("age").unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get<T: TryFrom<&'a Value>>(&self, column: &str) -> Option<T> {
         let i = self.columns.iter().position(|c| c == column)?;
         self.result.get(i)
@@ -35,7 +247,36 @@ impl<'a> Row<'a> {
 }
 
 impl sqlite::RowResult {
-    /// Get a value by its index
+    /// Get a value by its column name. The value is converted to the target type.
+    ///
+    /// * SQLite integers are convertible to Rust integer types (i8, u8, i16, etc. including usize and isize) and bool.
+    /// * SQLite strings are convertible to Rust &str or &[u8] (encoded as UTF-8).
+    /// * SQLite reals are convertible to Rust f64.
+    /// * SQLite blobs are convertible to Rust &[u8] or &str (interpreted as UTF-8).
+    ///
+    /// To look up by name, you can use `QueryResult::rows()` or obtain the invoice from `QueryResult::columns`.
+    /// If you do not know the type of a value, access the underlying [Value] enum directly
+    /// via the [RowResult::values] field
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spin_sdk::sqlite::{Connection, Value};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let user_id = 0;
+    /// let db = Connection::open_default()?;
+    /// let query_result = db.execute(
+    ///     "SELECT name, age FROM users WHERE id = ?",
+    ///     &[Value::Integer(user_id)]
+    /// )?;
+    /// let user_row = query_result.rows.first().unwrap();
+    ///
+    /// let name = user_row.get::<&str>(0).unwrap();
+    /// let age = user_row.get::<u16>(1).unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn get<'a, T: TryFrom<&'a Value>>(&'a self, index: usize) -> Option<T> {
         self.values.get(index).and_then(|c| c.try_into().ok())
     }


### PR DESCRIPTION
Fixes #34.  Further to https://github.com/fermyon/spin/issues/3007.

@kate-goldenring I'm opening this as draft with just a few KV examples done to get feedback on is this the kind of thing you are asking for, or am I missing the mark?  If you're happy with the style and approach then I'll press on, otherwise I'd be delighted to iterate with your guidance!

(For folks who want to see how it looks rendered, `cargo doc --lib --open`.)

As mentioned in https://github.com/fermyon/spin/issues/3007, there may be challenges with adding examples to methods defined in WIT, and it would be useful to understand how folks want to proceed there...  Note also that Rust appends the WIT docs at the end of the handwritten docs (after the examples) and I have not yet found an incantation to turn this off!

_(ETA: Lann asked for `http::send` examples - did some of those too.)_

_(ETA: per Kate's feedback, continuing to build out, a bit ad hoc but eh.)_