### PR TITLE
bump version to 3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin-executor"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "futures",
  "once_cell",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ wasmtime-wasi-http = "18.0.1"
 wit-component = "0.200.0"
 
 [workspace.package]
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -54,7 +54,7 @@ pub enum InferencingModel<'a> {
     Other(&'a str),
 }
 
-impl<'a> std::fmt::Display for InferencingModel<'a> {
+impl std::fmt::Display for InferencingModel<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
             InferencingModel::Llama2Chat => "llama2-chat",
@@ -100,7 +100,7 @@ pub enum EmbeddingModel<'a> {
     Other(&'a str),
 }
 
-impl<'a> std::fmt::Display for EmbeddingModel<'a> {
+impl std::fmt::Display for EmbeddingModel<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
             EmbeddingModel::AllMiniLmL6V2 => "all-minilm-l6-v2",


### PR DESCRIPTION
- add new `spin_executor::push_waker_and_get_token` function
    - My previous commit changed the return value of `push_waker`, which was a
breaking change.  Given that it was part of a bugfix that we'd like to make a
point release for, I've converted it to a non-breaking change by switching the
`push_waker` signature back and adding a new function instead.

- address clippy warnings in `src/llm.rs`

- bump version to 3.1.1