### PR TITLE
Spin 3.4 SQLite and PostgreSQL interfaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,18 @@ jobs:
           cargo fmt --all -- --check
           cargo clippy --workspace --all-targets -- -D warnings
         
+      - name: Check with no-default-features
+        shell: bash
+        run: cargo check --no-default-features
+
+      - name: Check with `json` feature only
+        shell: bash
+        run: cargo check --no-default-features --features json
+
+      - name: Check with `postgres4-types` feature only
+        shell: bash
+        run: cargo check --no-default-features --features postgres4-types
+
       - name: Test
         shell: bash
         run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,6 +1804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-outbound-pg-v4"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "http 1.0.0",
+ "spin-sdk",
+]
+
+[[package]]
 name = "rust-outbound-redis"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-spin-redis"
 version = "0.1.0"
 dependencies = [
@@ -169,7 +175,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -198,7 +204,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.0.8",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -209,7 +215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acb89ccf798a28683f00089d0630dfaceec087234eae0d308c05ddeaa941b40"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -510,6 +516,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -573,8 +580,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -779,6 +792,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +815,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -870,6 +895,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1087,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1148,10 +1182,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1238,6 +1273,16 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1433,6 +1478,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+]
+
+[[package]]
+name = "postgres_range"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6dce28dc5ba143d8eb157b62aac01ae5a1c585c40792158b720e86a87642101"
+dependencies = [
+ "postgres-protocol",
+ "postgres-types",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,14 +1574,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1507,7 +1607,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1516,7 +1626,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1554,7 +1673,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "libredox",
  "thiserror 1.0.57",
 ]
@@ -1621,7 +1740,7 @@ checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1693,6 +1812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,7 +1856,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1782,6 +1911,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2008,14 +2143,17 @@ dependencies = [
  "http-body-util",
  "hyper 1.2.0",
  "once_cell",
+ "postgres_range",
  "reqwest",
  "routefinder",
+ "rust_decimal",
  "serde",
  "serde_json",
  "spin-executor",
  "spin-macro",
  "thiserror 1.0.57",
  "tokio",
+ "uuid",
  "wasi 0.13.1+wasi-0.2.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -2064,6 +2202,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "subtle"
@@ -2132,7 +2281,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.31",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -2405,6 +2554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,9 +2590,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2476,6 +2635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt 0.39.0",
+]
+
+[[package]]
 name = "wasi-http-rust-streaming-outgoing-body"
 version = "0.1.0"
 dependencies = [
@@ -2489,23 +2657,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -2526,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2536,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2549,9 +2718,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -3057,7 +3229,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3298,6 +3470,15 @@ name = "wit-bindgen-rt"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
+dependencies = [
+ "bitflags 2.4.2",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.4.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ anyhow = "1"
 async-trait = "0.1.74"
 chrono = "0.4.38"
 form_urlencoded = "1.0"
-rust_decimal = { version = "1.37.2", default-features = false }
+postgres_range = { version = "0.11.1", optional = true }
+rust_decimal = { version = "1.37.2", default-features = false, optional = true }
 spin-executor = { version = "4.0.0", path = "crates/executor" }
 spin-macro = { version = "4.0.0", path = "crates/macro" }
 thiserror = "1.0.37"
+uuid = { version = "1.18.0", optional = true }
 wit-bindgen = { workspace = true }
 routefinder = "0.5.3"
 once_cell = { workspace = true }
@@ -34,13 +36,12 @@ hyperium = { package = "http", version = "1.0.0" }
 serde_json = { version = "1.0.96", optional = true }
 serde = { version = "1.0.163", optional = true }
 wasi = { workspace = true }
-uuid = "1.18.0"
-postgres_range = "0.11.1"
 
 [features]
-default = ["export-sdk-language", "json"]
+default = ["export-sdk-language", "json", "postgres4-types"]
 export-sdk-language = []
 json = ["dep:serde", "dep:serde_json"]
+postgres4-types = ["dep:rust_decimal", "dep:uuid", "dep:postgres_range", "json"]
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = "1"
 async-trait = "0.1.74"
 chrono = "0.4.38"
 form_urlencoded = "1.0"
+rust_decimal = { version = "1.37.2", default-features = false }
 spin-executor = { version = "4.0.0", path = "crates/executor" }
 spin-macro = { version = "4.0.0", path = "crates/macro" }
 thiserror = "1.0.37"
@@ -33,6 +34,8 @@ hyperium = { package = "http", version = "1.0.0" }
 serde_json = { version = "1.0.96", optional = true }
 serde = { version = "1.0.163", optional = true }
 wasi = { workspace = true }
+uuid = "1.18.0"
+postgres_range = "0.11.1"
 
 [features]
 default = ["export-sdk-language", "json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
   "examples/mysql",
   "examples/postgres",
   "examples/postgres-v3",
+  "examples/postgres-v4",
   "examples/redis-outbound",
   "examples/mqtt-outbound",
   "examples/variables",

--- a/examples/postgres-v4/.cargo/config.toml
+++ b/examples/postgres-v4/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasip1"

--- a/examples/postgres-v4/Cargo.toml
+++ b/examples/postgres-v4/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rust-outbound-pg-v4"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# Useful crate to handle errors.
+anyhow = "1"
+# General-purpose crate with common HTTP types.
+http = "1.0.0"
+# The Spin SDK.
+spin-sdk = { path = "../.." }

--- a/examples/postgres-v4/README.md
+++ b/examples/postgres-v4/README.md
@@ -1,0 +1,36 @@
+# Spin Outbound PostgreSQL example
+
+This example shows how to access a PostgreSQL database from a Spin component.
+It shows the new PostgreSQL range support in the v4 interface.
+
+## Prerequisite: Postgres
+
+This example assumes postgres is running and accessible locally via its standard 5432 port.
+
+We suggest running the `postgres` Docker container which has the necessary postgres user permissions
+already configured. For example:
+
+```
+docker run --rm -h 127.0.0.1 -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres
+```
+
+## Spin up
+
+Then, run the following from the root of this example:
+
+```
+createdb -h localhost -U postgres spin_dev
+psql -h localhost -U postgres -d spin_dev -f db/testdata.sql
+spin build --up
+```
+
+Curl with a year between 2005 and today as the path:
+
+```
+$ curl -i localhost:3000/2016
+HTTP/1.1 200 OK
+transfer-encoding: chunked
+date: Mon, 18 Aug 2025 05:02:29 GMT
+
+Splodge and Fang and Kiki and Slats
+```

--- a/examples/postgres-v4/db/testdata.sql
+++ b/examples/postgres-v4/db/testdata.sql
@@ -1,0 +1,14 @@
+CREATE TABLE cats (
+   name text not null,
+   reign int4range not null
+);
+
+INSERT INTO cats (name, reign) VALUES
+   ('Smoke', '[2005, 2013]'::int4range),
+   ('Splodge', '[2005, 2019]'::int4range),
+   ('Fang', '[2005, 2016]'::int4range),
+   ('Kiki', '[2005, 2020]'::int4range),
+   ('Slats', '[2005, 2021]'::int4range),
+   ('Rosie', '[2021,)'::int4range),
+   ('Hobbes', '[2021,)'::int4range)
+;

--- a/examples/postgres-v4/spin.toml
+++ b/examples/postgres-v4/spin.toml
@@ -1,0 +1,17 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+name = "rust-outbound-pg-v4-example"
+version = "0.1.0"
+
+[[trigger.http]]
+route = "/:year"
+component = "outbound-pg"
+
+[component.outbound-pg]
+environment = { DB_URL = "host=localhost user=postgres dbname=spin_dev" }
+source = "../../target/wasm32-wasip1/release/rust_outbound_pg_v4.wasm"
+allowed_outbound_hosts = ["postgres://localhost"]
+[component.outbound-pg.build]
+command = "cargo build --target wasm32-wasip1 --release"

--- a/examples/postgres-v4/src/lib.rs
+++ b/examples/postgres-v4/src/lib.rs
@@ -1,0 +1,42 @@
+#![allow(dead_code)]
+use anyhow::Result;
+use http::{Request, Response};
+use spin_sdk::{http_component, pg3, pg3::Decode};
+
+// The environment variable set in `spin.toml` that points to the
+// address of the Pg server that the component will write to
+const DB_URL_ENV: &str = "DB_URL";
+
+#[http_component]
+fn process(req: Request<()>) -> Result<Response<String>> {
+    let address = std::env::var(DB_URL_ENV)?;
+    let conn = pg3::Connection::open(&address)?;
+
+    let year_header = req
+        .headers()
+        .get("spin-path-match-year")
+        .map(|hv| hv.to_str())
+        .transpose()?
+        .unwrap_or("2025");
+    let year: i32 = year_header.parse()?;
+
+    // Due to an ambiguity in the PostgreSQL `<@` operator syntax, we MUST qualify
+    // the year as an int4 rather than an int4range in the query.
+    let rulers = conn.query(
+        "SELECT name FROM cats WHERE $1::int4 <@ reign",
+        &[year.into()],
+    )?;
+
+    let response = if rulers.rows.is_empty() {
+        "it was anarchy".to_owned()
+    } else {
+        let ruler_names = rulers
+            .rows
+            .into_iter()
+            .map(|r| Decode::decode(&r[0]))
+            .collect::<Result<Vec<String>, _>>()?;
+        ruler_names.join(" and ")
+    };
+
+    Ok(http::Response::builder().body(format!("{response}\n"))?)
+}

--- a/src/http/conversions.rs
+++ b/src/http/conversions.rs
@@ -5,9 +5,11 @@ use async_trait::async_trait;
 use wasi::io::streams;
 
 use super::{
-    Headers, IncomingRequest, IncomingResponse, Json, JsonBodyError, Method, OutgoingRequest,
-    OutgoingResponse, RequestBuilder,
+    Headers, IncomingRequest, IncomingResponse, Method, OutgoingRequest, OutgoingResponse,
+    RequestBuilder,
 };
+#[cfg(feature = "json")]
+use super::{Json, JsonBodyError};
 
 use super::{responses, NonUtf8BodyError, Request, Response};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod test;
 pub mod key_value;
 
 /// SQLite storage for Spin 2 and earlier. Applications that do not require
-/// this backward compatibility should use the [`sqlite3`](crate::sqlite3) module instead.
+/// this backward compatibility should use the [`sqlite3`] module instead.
 pub mod sqlite;
 /// SQLite storage.
 pub mod sqlite3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,11 @@ mod test;
 /// Key/Value storage.
 pub mod key_value;
 
-/// SQLite storage.
+/// SQLite storage for Spin 2 and earlier. Applications that do not require
+/// this backward compatibility should use the [`sqlite3`](crate::sqlite3) module instead.
 pub mod sqlite;
+/// SQLite storage.
+pub mod sqlite3;
 
 /// Large Language Model (Serverless AI) APIs
 pub mod llm;
@@ -34,7 +37,9 @@ pub mod wit {
         generate_all,
     });
     pub use fermyon::spin2_0_0 as v2;
-    pub use spin::postgres::postgres as pg3;
+    pub use spin::postgres3_0_0::postgres as pg3;
+    pub use spin::postgres4_0_0::postgres as pg4;
+    pub use spin::sqlite::sqlite as sqlite3;
 }
 
 #[export_name = concat!("spin-sdk-version-", env!("SDK_VERSION"))]
@@ -56,8 +61,8 @@ pub mod mqtt;
 pub mod redis;
 
 pub mod pg;
-
 pub mod pg3;
+pub mod pg4;
 
 pub mod mysql;
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -1,5 +1,5 @@
-//! Spin 2 Postgres relational database storage. Applications that do not require
-//! Spin 2 support should use the [`pg3`](crate::pg3) module instead.
+//! Postgres relational database storage for Spin 2 and earlier. Applications that do not require
+//! this backward compatibility should use the [`pg4`](crate::pg4) module instead.
 //!
 //! Conversions between Rust, WIT and **Postgres** types.
 //!

--- a/src/pg4.rs
+++ b/src/pg4.rs
@@ -27,12 +27,12 @@
 //! | `chrono::Duration`      | timestamp(s64)                                | BIGINT                       |
 //! | `uuid::Uuid`            | uuid(string)                                  | UUID                         |
 //! | `serde_json::Value`     | jsonb(list\<u8\>)                             | JSONB                        |
-//! | `serde::De/Serialize    | jsonb(list\<u8\>)                             | JSONB                        |
+//! | `serde::De/Serialize`   | jsonb(list\<u8\>)                             | JSONB                        |
 //! | `rust_decimal::Decimal` | decimal(string)                               | NUMERIC                      |
 //! | `postgres_range`        | range-int32(...), range-int64(...)            | INT4RANGE, INT8RANGE         |
 //! | lower/upper tuple       | range-decimal(...)                            | NUMERICRANGE                 |
 //! | `Vec<Option<...>>`      | array-int32(...), array-int64(...), array-str(...), array-decimal(...) | INT4[], INT8[], TEXT[], NUMERIC[] |
-//! | `pg4::Interval          | interval(interval)                            | INTERVAL                     |
+//! | `pg4::Interval`         | interval(interval)                            | INTERVAL                     |
 
 /// An open connection to a PostgreSQL database.
 ///

--- a/src/pg4.rs
+++ b/src/pg4.rs
@@ -1,5 +1,8 @@
-//! Postgres relational database storage for Spin 3.3 and earlier. Applications that do not require
-//! this backward compatibility should use the [`pg4`](crate::pg4) module instead.
+// pg4 errors can be large, because they now include a breakdown of the PostgreSQL
+// error fields instead of just a string
+#![allow(clippy::result_large_err)]
+
+//! Postgres relational database storage.
 //!
 //! You can use the [`into()`](std::convert::Into) method to convert
 //! a Rust value into a [`ParameterValue`]. You can use the
@@ -22,6 +25,14 @@
 //! | `chrono::NaiveTime`     | time(tuple<u8, u8, u8, u32>)                  | TIME                         |
 //! | `chrono::NaiveDateTime` | datetime(tuple<s32, u8, u8, u8, u8, u8, u32>) | TIMESTAMP                    |
 //! | `chrono::Duration`      | timestamp(s64)                                | BIGINT                       |
+//! | `uuid::Uuid`            | uuid(string)                                  | UUID                         |
+//! | `serde_json::Value`     | jsonb(list\<u8\>)                             | JSONB                        |
+//! | `serde::De/Serialize    | jsonb(list\<u8\>)                             | JSONB                        |
+//! | `rust_decimal::Decimal` | decimal(string)                               | NUMERIC                      |
+//! | `postgres_range`        | range-int32(...), range-int64(...)            | INT4RANGE, INT8RANGE         |
+//! | lower/upper tuple       | range-decimal(...)                            | NUMERICRANGE                 |
+//! | `Vec<Option<...>>`      | array-int32(...), array-int64(...), array-str(...), array-decimal(...) | INT4[], INT8[], TEXT[], NUMERIC[] |
+//! | `pg4::Interval          | interval(interval)                            | INTERVAL                     |
 
 /// An open connection to a PostgreSQL database.
 ///
@@ -30,7 +41,7 @@
 /// Load a set of rows from a local PostgreSQL database, and iterate over them.
 ///
 /// ```no_run
-/// use spin_sdk::pg3::{Connection, Decode};
+/// use spin_sdk::pg4::{Connection, Decode};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// # let min_age = 0;
@@ -55,7 +66,7 @@
 /// contains a single column, with a single row.
 ///
 /// ```no_run
-/// use spin_sdk::pg3::{Connection, Decode};
+/// use spin_sdk::pg4::{Connection, Decode};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let db = Connection::open("host=localhost user=postgres password=my_password dbname=mydb")?;
@@ -75,7 +86,7 @@
 /// instead of the `query` method.
 ///
 /// ```no_run
-/// use spin_sdk::pg3::Connection;
+/// use spin_sdk::pg4::Connection;
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let db = Connection::open("host=localhost user=postgres password=my_password dbname=mydb")?;
@@ -88,7 +99,7 @@
 /// # }
 /// ```
 #[doc(inline)]
-pub use super::wit::pg3::Connection;
+pub use super::wit::pg4::Connection;
 
 /// The result of a database query.
 ///
@@ -100,7 +111,7 @@ pub use super::wit::pg3::Connection;
 /// specific columns in the query.
 ///
 /// ```no_run
-/// use spin_sdk::pg3::{Connection, Decode};
+/// use spin_sdk::pg4::{Connection, Decode};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// # let min_age = 0;
@@ -120,10 +131,13 @@ pub use super::wit::pg3::Connection;
 /// # Ok(())
 /// # }
 /// ```
-pub use super::wit::pg3::RowSet;
+pub use super::wit::pg4::RowSet;
 
 #[doc(inline)]
-pub use super::wit::pg3::{Error as PgError, *};
+pub use super::wit::pg4::{Error as PgError, *};
+
+/// The PostgreSQL INTERVAL data type.
+pub use crate::pg4::Interval;
 
 use chrono::{Datelike, Timelike};
 
@@ -314,6 +328,140 @@ impl Decode for chrono::Duration {
     }
 }
 
+impl Decode for uuid::Uuid {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::Uuid(s) => uuid::Uuid::parse_str(s).map_err(|e| Error::Decode(e.to_string())),
+            _ => Err(Error::Decode(format_decode_err("UUID", value))),
+        }
+    }
+}
+
+impl Decode for serde_json::Value {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        from_jsonb(value)
+    }
+}
+
+/// Convert a Postgres JSONB value to a `Deserialize`-able type.
+pub fn from_jsonb<'a, T: serde::Deserialize<'a>>(value: &'a DbValue) -> Result<T, Error> {
+    match value {
+        DbValue::Jsonb(j) => serde_json::from_slice(j).map_err(|e| Error::Decode(e.to_string())),
+        _ => Err(Error::Decode(format_decode_err("JSONB", value))),
+    }
+}
+
+impl Decode for rust_decimal::Decimal {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::Decimal(s) => {
+                rust_decimal::Decimal::from_str_exact(s).map_err(|e| Error::Decode(e.to_string()))
+            }
+            _ => Err(Error::Decode(format_decode_err("NUMERIC", value))),
+        }
+    }
+}
+
+fn bound_type_from_wit(kind: RangeBoundKind) -> postgres_range::BoundType {
+    match kind {
+        RangeBoundKind::Inclusive => postgres_range::BoundType::Inclusive,
+        RangeBoundKind::Exclusive => postgres_range::BoundType::Exclusive,
+    }
+}
+
+impl Decode for postgres_range::Range<i32> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::RangeInt32((lbound, ubound)) => {
+                let lower = lbound.map(|(value, kind)| {
+                    postgres_range::RangeBound::new(value, bound_type_from_wit(kind))
+                });
+                let upper = ubound.map(|(value, kind)| {
+                    postgres_range::RangeBound::new(value, bound_type_from_wit(kind))
+                });
+                Ok(postgres_range::Range::new(lower, upper))
+            }
+            _ => Err(Error::Decode(format_decode_err("INT4RANGE", value))),
+        }
+    }
+}
+
+impl Decode for postgres_range::Range<i64> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::RangeInt64((lbound, ubound)) => {
+                let lower = lbound.map(|(value, kind)| {
+                    postgres_range::RangeBound::new(value, bound_type_from_wit(kind))
+                });
+                let upper = ubound.map(|(value, kind)| {
+                    postgres_range::RangeBound::new(value, bound_type_from_wit(kind))
+                });
+                Ok(postgres_range::Range::new(lower, upper))
+            }
+            _ => Err(Error::Decode(format_decode_err("INT8RANGE", value))),
+        }
+    }
+}
+
+// TODO: NUMERICRANGE
+
+// TODO: can we return a slice here? It seems like it should be possible but
+// I wasn't able to get the lifetimes to work with the trait
+impl Decode for Vec<Option<i32>> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::ArrayInt32(a) => Ok(a.to_vec()),
+            _ => Err(Error::Decode(format_decode_err("INT4[]", value))),
+        }
+    }
+}
+
+impl Decode for Vec<Option<i64>> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::ArrayInt64(a) => Ok(a.to_vec()),
+            _ => Err(Error::Decode(format_decode_err("INT8[]", value))),
+        }
+    }
+}
+
+impl Decode for Vec<Option<String>> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::ArrayStr(a) => Ok(a.to_vec()),
+            _ => Err(Error::Decode(format_decode_err("TEXT[]", value))),
+        }
+    }
+}
+
+fn map_decimal(s: &Option<String>) -> Result<Option<rust_decimal::Decimal>, Error> {
+    s.as_ref()
+        .map(|s| rust_decimal::Decimal::from_str_exact(s))
+        .transpose()
+        .map_err(|e| Error::Decode(e.to_string()))
+}
+
+impl Decode for Vec<Option<rust_decimal::Decimal>> {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::ArrayDecimal(a) => {
+                let decs = a.iter().map(map_decimal).collect::<Result<_, _>>()?;
+                Ok(decs)
+            }
+            _ => Err(Error::Decode(format_decode_err("NUMERIC[]", value))),
+        }
+    }
+}
+
+impl Decode for Interval {
+    fn decode(value: &DbValue) -> Result<Self, Error> {
+        match value {
+            DbValue::Interval(i) => Ok(*i),
+            _ => Err(Error::Decode(format_decode_err("INTERVAL", value))),
+        }
+    }
+}
+
 macro_rules! impl_parameter_value_conversions {
     ($($ty:ty => $id:ident),*) => {
         $(
@@ -335,7 +483,10 @@ impl_parameter_value_conversions! {
     f64 => Floating64,
     bool => Boolean,
     String => Str,
-    Vec<u8> => Binary
+    Vec<u8> => Binary,
+    Vec<Option<i32>> => ArrayInt32,
+    Vec<Option<i64>> => ArrayInt64,
+    Vec<Option<String>> => ArrayStr
 }
 
 impl From<chrono::NaiveDateTime> for ParameterValue {
@@ -372,6 +523,193 @@ impl From<chrono::NaiveDate> for ParameterValue {
 impl From<chrono::TimeDelta> for ParameterValue {
     fn from(v: chrono::TimeDelta) -> ParameterValue {
         ParameterValue::Timestamp(v.num_seconds())
+    }
+}
+
+impl From<uuid::Uuid> for ParameterValue {
+    fn from(v: uuid::Uuid) -> ParameterValue {
+        ParameterValue::Uuid(v.to_string())
+    }
+}
+
+impl TryFrom<serde_json::Value> for ParameterValue {
+    type Error = serde_json::Error;
+
+    fn try_from(v: serde_json::Value) -> Result<ParameterValue, Self::Error> {
+        jsonb(&v)
+    }
+}
+
+/// Converts a `Serialize` value to a Postgres JSONB SQL parameter.
+pub fn jsonb<T: serde::Serialize>(value: &T) -> Result<ParameterValue, serde_json::Error> {
+    let json = serde_json::to_vec(value)?;
+    Ok(ParameterValue::Jsonb(json))
+}
+
+impl From<rust_decimal::Decimal> for ParameterValue {
+    fn from(v: rust_decimal::Decimal) -> ParameterValue {
+        ParameterValue::Decimal(v.to_string())
+    }
+}
+
+// We cannot impl From<T: RangeBounds<...>> because Rust fears that some future
+// knave or rogue might one day add RangeBounds to NaiveDateTime. The best we can
+// do is therefore a helper function we can call from range Froms.
+#[allow(
+    clippy::type_complexity,
+    reason = "I sure hope 'blame Alex' works here too"
+)]
+fn range_bounds_to_wit<T, U>(
+    range: impl std::ops::RangeBounds<T>,
+    f: impl Fn(&T) -> U,
+) -> (Option<(U, RangeBoundKind)>, Option<(U, RangeBoundKind)>) {
+    (
+        range_bound_to_wit(range.start_bound(), &f),
+        range_bound_to_wit(range.end_bound(), &f),
+    )
+}
+
+fn range_bound_to_wit<T, U>(
+    bound: std::ops::Bound<&T>,
+    f: &dyn Fn(&T) -> U,
+) -> Option<(U, RangeBoundKind)> {
+    match bound {
+        std::ops::Bound::Included(v) => Some((f(v), RangeBoundKind::Inclusive)),
+        std::ops::Bound::Excluded(v) => Some((f(v), RangeBoundKind::Exclusive)),
+        std::ops::Bound::Unbounded => None,
+    }
+}
+
+fn pg_range_bound_to_wit<S: postgres_range::BoundSided, T: Copy>(
+    bound: &postgres_range::RangeBound<S, T>,
+) -> (T, RangeBoundKind) {
+    let kind = match &bound.type_ {
+        postgres_range::BoundType::Inclusive => RangeBoundKind::Inclusive,
+        postgres_range::BoundType::Exclusive => RangeBoundKind::Exclusive,
+    };
+    (bound.value, kind)
+}
+
+impl From<std::ops::Range<i32>> for ParameterValue {
+    fn from(v: std::ops::Range<i32>) -> ParameterValue {
+        ParameterValue::RangeInt32(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeInclusive<i32>> for ParameterValue {
+    fn from(v: std::ops::RangeInclusive<i32>) -> ParameterValue {
+        ParameterValue::RangeInt32(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeFrom<i32>> for ParameterValue {
+    fn from(v: std::ops::RangeFrom<i32>) -> ParameterValue {
+        ParameterValue::RangeInt32(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeTo<i32>> for ParameterValue {
+    fn from(v: std::ops::RangeTo<i32>) -> ParameterValue {
+        ParameterValue::RangeInt32(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeToInclusive<i32>> for ParameterValue {
+    fn from(v: std::ops::RangeToInclusive<i32>) -> ParameterValue {
+        ParameterValue::RangeInt32(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<postgres_range::Range<i32>> for ParameterValue {
+    fn from(v: postgres_range::Range<i32>) -> ParameterValue {
+        let lbound = v.lower().map(pg_range_bound_to_wit);
+        let ubound = v.upper().map(pg_range_bound_to_wit);
+        ParameterValue::RangeInt32((lbound, ubound))
+    }
+}
+
+impl From<std::ops::Range<i64>> for ParameterValue {
+    fn from(v: std::ops::Range<i64>) -> ParameterValue {
+        ParameterValue::RangeInt64(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeInclusive<i64>> for ParameterValue {
+    fn from(v: std::ops::RangeInclusive<i64>) -> ParameterValue {
+        ParameterValue::RangeInt64(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeFrom<i64>> for ParameterValue {
+    fn from(v: std::ops::RangeFrom<i64>) -> ParameterValue {
+        ParameterValue::RangeInt64(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeTo<i64>> for ParameterValue {
+    fn from(v: std::ops::RangeTo<i64>) -> ParameterValue {
+        ParameterValue::RangeInt64(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<std::ops::RangeToInclusive<i64>> for ParameterValue {
+    fn from(v: std::ops::RangeToInclusive<i64>) -> ParameterValue {
+        ParameterValue::RangeInt64(range_bounds_to_wit(v, |n| *n))
+    }
+}
+
+impl From<postgres_range::Range<i64>> for ParameterValue {
+    fn from(v: postgres_range::Range<i64>) -> ParameterValue {
+        let lbound = v.lower().map(pg_range_bound_to_wit);
+        let ubound = v.upper().map(pg_range_bound_to_wit);
+        ParameterValue::RangeInt64((lbound, ubound))
+    }
+}
+
+impl From<std::ops::Range<rust_decimal::Decimal>> for ParameterValue {
+    fn from(v: std::ops::Range<rust_decimal::Decimal>) -> ParameterValue {
+        ParameterValue::RangeDecimal(range_bounds_to_wit(v, |d| d.to_string()))
+    }
+}
+
+impl From<Vec<i32>> for ParameterValue {
+    fn from(v: Vec<i32>) -> ParameterValue {
+        ParameterValue::ArrayInt32(v.into_iter().map(Some).collect())
+    }
+}
+
+impl From<Vec<i64>> for ParameterValue {
+    fn from(v: Vec<i64>) -> ParameterValue {
+        ParameterValue::ArrayInt64(v.into_iter().map(Some).collect())
+    }
+}
+
+impl From<Vec<String>> for ParameterValue {
+    fn from(v: Vec<String>) -> ParameterValue {
+        ParameterValue::ArrayStr(v.into_iter().map(Some).collect())
+    }
+}
+
+impl From<Vec<Option<rust_decimal::Decimal>>> for ParameterValue {
+    fn from(v: Vec<Option<rust_decimal::Decimal>>) -> ParameterValue {
+        let strs = v
+            .into_iter()
+            .map(|optd| optd.map(|d| d.to_string()))
+            .collect();
+        ParameterValue::ArrayDecimal(strs)
+    }
+}
+
+impl From<Vec<rust_decimal::Decimal>> for ParameterValue {
+    fn from(v: Vec<rust_decimal::Decimal>) -> ParameterValue {
+        let strs = v.into_iter().map(|d| Some(d.to_string())).collect();
+        ParameterValue::ArrayDecimal(strs)
+    }
+}
+
+impl From<Interval> for ParameterValue {
+    fn from(v: Interval) -> ParameterValue {
+        ParameterValue::Interval(v)
     }
 }
 

--- a/src/sqlite3.rs
+++ b/src/sqlite3.rs
@@ -1,0 +1,345 @@
+use super::wit::sqlite3;
+
+#[doc(inline)]
+pub use sqlite3::{Error, Value};
+
+/// An open connection to a SQLite database.
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Use the [QueryResult::rows()] wrapper to access a column by name. This is simpler and
+/// more readable but incurs a lookup on each access, so is not recommended when
+/// iterating a data set.
+///
+/// ```no_run
+/// # use spin_sdk::sqlite::{Connection, Value};
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open_default()?;
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE id = ?",
+///     &[Value::Integer(user_id)]
+/// )?;
+/// let name = query_result.rows().next().and_then(|r| r.get::<&str>("name")).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Perform an aggregate (scalar) operation over a named SQLite database. The result
+/// set contains a single column, with a single row.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::Connection;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open("customer-data")?;
+/// let query_result = db.execute("SELECT COUNT(*) FROM users", &[])?;
+/// let count = query_result.rows.first().and_then(|r| r.get::<usize>(0)).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Delete rows from a SQLite database. The usual [Connection::execute()] syntax
+/// is used but the query result is always empty.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 18;
+/// let db = Connection::open("customer-data")?;
+/// db.execute("DELETE FROM users WHERE age < ?", &[Value::Integer(min_age)])?;
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use sqlite3::Connection;
+
+/// The result of a SQLite query issued with [Connection::execute()].
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Use the [QueryResult::rows()] wrapper to access a column by name. This is simpler and
+/// more readable but incurs a lookup on each access, so is not recommended when
+/// iterating a data set.
+///
+/// ```no_run
+/// # use spin_sdk::sqlite::{Connection, Value};
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open_default()?;
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE id = ?",
+///     &[Value::Integer(user_id)]
+/// )?;
+/// let name = query_result.rows().next().and_then(|r| r.get::<&str>("name")).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Perform an aggregate (scalar) operation over a named SQLite database. The result
+/// set contains a single column, with a single row.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::Connection;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let user_id = 0;
+/// let db = Connection::open("customer-data")?;
+/// let query_result = db.execute("SELECT COUNT(*) FROM users", &[])?;
+/// let count = query_result.rows.first().and_then(|r| r.get::<usize>(0)).unwrap();
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use sqlite3::QueryResult;
+
+/// A database row result.
+///
+/// There are two representations of a SQLite row in the SDK. This type is obtained from
+/// the [field@QueryResult::rows] field, and provides index-based lookup or low-level access
+/// to row values via a vector. The [Row] type is useful for
+/// addressing elements by column name, and is obtained from the [QueryResult::rows()] function.
+///
+/// # Examples
+///
+/// Load a set of rows from the default SQLite database, and iterate over them selecting one
+/// field from each. The example caches the index of the desired field to avoid repeated lookup,
+/// making this more efficient than the [Row]-based equivalent at the expense of
+/// extra code and inferior readability.
+///
+/// ```no_run
+/// use spin_sdk::sqlite::{Connection, Value};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// # let min_age = 0;
+/// let db = Connection::open_default()?;
+///
+/// let query_result = db.execute(
+///     "SELECT * FROM users WHERE age >= ?",
+///     &[Value::Integer(min_age)]
+/// )?;
+///
+/// let name_index = query_result.columns.iter().position(|c| c == "name").unwrap();
+///
+/// for row in &query_result.rows {
+///     let name: &str = row.get(name_index).unwrap();
+///     println!("Found user {name}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[doc(inline)]
+pub use sqlite3::RowResult;
+
+impl sqlite3::Connection {
+    /// Open a connection to the default database
+    pub fn open_default() -> Result<Self, Error> {
+        Self::open("default")
+    }
+}
+
+impl sqlite3::QueryResult {
+    /// Get all the rows for this query result
+    pub fn rows(&self) -> impl Iterator<Item = Row<'_>> {
+        self.rows.iter().map(|r| Row {
+            columns: self.columns.as_slice(),
+            result: r,
+        })
+    }
+}
+
+/// A database row result.
+///
+/// There are two representations of a SQLite row in the SDK.  This type is useful for
+/// addressing elements by column name, and is obtained from the [QueryResult::rows()] function.
+/// The [RowResult] type is obtained from the [field@QueryResult::rows] field, and provides
+/// index-based lookup or low-level access to row values via a vector.
+pub struct Row<'a> {
+    columns: &'a [String],
+    result: &'a sqlite3::RowResult,
+}
+
+impl<'a> Row<'a> {
+    /// Get a value by its column name. The value is converted to the target type.
+    ///
+    /// * SQLite integers are convertible to Rust integer types (i8, u8, i16, etc. including usize and isize) and bool.
+    /// * SQLite strings are convertible to Rust &str or &[u8] (encoded as UTF-8).
+    /// * SQLite reals are convertible to Rust f64.
+    /// * SQLite blobs are convertible to Rust &[u8] or &str (interpreted as UTF-8).
+    ///
+    /// If your code does not know the type in advance, use [RowResult] instead of `Row` to
+    /// access the underlying [Value] enum.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spin_sdk::sqlite::{Connection, Value};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let user_id = 0;
+    /// let db = Connection::open_default()?;
+    /// let query_result = db.execute(
+    ///     "SELECT * FROM users WHERE id = ?",
+    ///     &[Value::Integer(user_id)]
+    /// )?;
+    /// let user_row = query_result.rows().next().unwrap();
+    ///
+    /// let name = user_row.get::<&str>("name").unwrap();
+    /// let age = user_row.get::<u16>("age").unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get<T: TryFrom<&'a Value>>(&self, column: &str) -> Option<T> {
+        let i = self.columns.iter().position(|c| c == column)?;
+        self.result.get(i)
+    }
+}
+
+impl sqlite3::RowResult {
+    /// Get a value by its column name. The value is converted to the target type.
+    ///
+    /// * SQLite integers are convertible to Rust integer types (i8, u8, i16, etc. including usize and isize) and bool.
+    /// * SQLite strings are convertible to Rust &str or &[u8] (encoded as UTF-8).
+    /// * SQLite reals are convertible to Rust f64.
+    /// * SQLite blobs are convertible to Rust &[u8] or &str (interpreted as UTF-8).
+    ///
+    /// To look up by name, you can use `QueryResult::rows()` or obtain the invoice from `QueryResult::columns`.
+    /// If you do not know the type of a value, access the underlying [Value] enum directly
+    /// via the [RowResult::values] field
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spin_sdk::sqlite::{Connection, Value};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let user_id = 0;
+    /// let db = Connection::open_default()?;
+    /// let query_result = db.execute(
+    ///     "SELECT name, age FROM users WHERE id = ?",
+    ///     &[Value::Integer(user_id)]
+    /// )?;
+    /// let user_row = query_result.rows.first().unwrap();
+    ///
+    /// let name = user_row.get::<&str>(0).unwrap();
+    /// let age = user_row.get::<u16>(1).unwrap();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get<'a, T: TryFrom<&'a Value>>(&'a self, index: usize) -> Option<T> {
+        self.values.get(index).and_then(|c| c.try_into().ok())
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for bool {
+    type Error = ();
+
+    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Integer(i) => Ok(*i != 0),
+            _ => Err(()),
+        }
+    }
+}
+
+macro_rules! int_conversions {
+    ($($t:ty),*) => {
+        $(impl<'a> TryFrom<&'a Value> for $t {
+            type Error = ();
+
+            fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+                match value {
+                    Value::Integer(i) => (*i).try_into().map_err(|_| ()),
+                    _ => Err(()),
+                }
+            }
+        })*
+    };
+}
+
+int_conversions!(u8, u16, u32, u64, i8, i16, i32, i64, usize, isize);
+
+impl<'a> TryFrom<&'a Value> for f64 {
+    type Error = ();
+
+    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Real(f) => Ok(*f),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for &'a str {
+    type Error = ();
+
+    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Text(s) => Ok(s.as_str()),
+            Value::Blob(b) => std::str::from_utf8(b).map_err(|_| ()),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for &'a [u8] {
+    type Error = ();
+
+    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Blob(b) => Ok(b.as_slice()),
+            Value::Text(s) => Ok(s.as_bytes()),
+            _ => Err(()),
+        }
+    }
+}

--- a/wit/deps/keyvalue-2024-10-17/atomic.wit
+++ b/wit/deps/keyvalue-2024-10-17/atomic.wit
@@ -13,22 +13,22 @@ interface atomics {
 
   /// The error returned by a CAS operation
   variant cas-error {
-	/// A store error occurred when performing the operation
-	store-error(error),
+    /// A store error occurred when performing the operation
+    store-error(error),
 	  /// The CAS operation failed because the value was too old. This returns a new CAS handle
 	  /// for easy retries. Implementors MUST return a CAS handle that has been updated to the
 	  /// latest version or transaction.
-	cas-failed(cas),
+	  cas-failed(cas),
   }
 
   /// A handle to a CAS (compare-and-swap) operation.
   resource cas {
-	/// Construct a new CAS operation. Implementors can map the underlying functionality
-	/// (transactions, versions, etc) as desired.
-	new: static func(bucket: borrow<bucket>, key: string) -> result<cas, error>;
-	/// Get the current value of the key (if it exists). This allows for avoiding reads if all
-	/// that is needed to ensure the atomicity of the operation
-	current: func() -> result<option<list<u8>>, error>;
+    /// Construct a new CAS operation. Implementors can map the underlying functionality
+    /// (transactions, versions, etc) as desired.
+    new: static func(bucket: borrow<bucket>, key: string) -> result<cas, error>;
+    /// Get the current value of the key (if it exists). This allows for avoiding reads if all
+    /// that is needed to ensure the atomicity of the operation
+    current: func() -> result<option<list<u8>>, error>;
   }
 
   /// Atomically increment the value associated with the key in the store by the given delta. It

--- a/wit/deps/keyvalue-2024-10-17/world.wit
+++ b/wit/deps/keyvalue-2024-10-17/world.wit
@@ -1,4 +1,4 @@
-package wasi: keyvalue@0.2.0-draft2;
+package wasi:keyvalue@0.2.0-draft2;
 
 /// The `wasi:keyvalue/imports` world provides common APIs for interacting with key-value stores.
 /// Components targeting this world will be able to do:

--- a/wit/deps/spin-postgres@4.0.0/postgres.wit
+++ b/wit/deps/spin-postgres@4.0.0/postgres.wit
@@ -1,0 +1,163 @@
+package spin:postgres@4.0.0;
+
+interface postgres {
+  /// Errors related to interacting with a database.
+  variant error {
+      connection-failed(string),
+      bad-parameter(string),
+      query-failed(query-error),
+      value-conversion-failed(string),
+      other(string)
+  }
+
+  variant query-error {
+      /// An error occurred but we do not have structured info for it
+      text(string),
+      /// Postgres returned a structured database error
+      db-error(db-error),
+  }
+
+  record db-error {
+      /// Stringised version of the error. This is primarily to facilitate migration of older code.
+      as-text: string,
+      severity: string,
+      code: string,
+      message: string,
+      detail: option<string>,
+      /// Any error information provided by Postgres and not captured above.
+      extras: list<tuple<string, string>>,
+  }
+
+  /// Data types for a database column
+  variant db-data-type {
+      boolean,
+      int8,
+      int16,
+      int32,
+      int64,
+      floating32,
+      floating64,
+      str,
+      binary,
+      date,
+      time,
+      datetime,
+      timestamp,
+      uuid,
+      jsonb,
+      decimal,
+      range-int32,
+      range-int64,
+      range-decimal,
+      array-int32,
+      array-int64,
+      array-decimal,
+      array-str,
+      interval,
+      other(string),
+  }
+
+  /// Database values
+  variant db-value {
+      boolean(bool),
+      int8(s8),
+      int16(s16),
+      int32(s32),
+      int64(s64),
+      floating32(f32),
+      floating64(f64),
+      str(string),
+      binary(list<u8>),
+      date(tuple<s32, u8, u8>), // (year, month, day)
+      time(tuple<u8, u8, u8, u32>), // (hour, minute, second, nanosecond)
+      /// Date-time types are always treated as UTC (without timezone info).
+      /// The instant is represented as a (year, month, day, hour, minute, second, nanosecond) tuple.
+      datetime(tuple<s32, u8, u8, u8, u8, u8, u32>),
+      /// Unix timestamp (seconds since epoch)
+      timestamp(s64),
+      uuid(string),
+      jsonb(list<u8>),
+      decimal(string), // I admit defeat. Base 10
+      range-int32(tuple<option<tuple<s32, range-bound-kind>>, option<tuple<s32, range-bound-kind>>>),
+      range-int64(tuple<option<tuple<s64, range-bound-kind>>, option<tuple<s64, range-bound-kind>>>),
+      range-decimal(tuple<option<tuple<string, range-bound-kind>>, option<tuple<string, range-bound-kind>>>),
+      array-int32(list<option<s32>>),
+      array-int64(list<option<s64>>),
+      array-decimal(list<option<string>>),
+      array-str(list<option<string>>),
+      interval(interval),
+      db-null,
+      unsupported(list<u8>),
+  }
+
+  /// Values used in parameterized queries
+  variant parameter-value {
+      boolean(bool),
+      int8(s8),
+      int16(s16),
+      int32(s32),
+      int64(s64),
+      floating32(f32),
+      floating64(f64),
+      str(string),
+      binary(list<u8>),
+      date(tuple<s32, u8, u8>), // (year, month, day)
+      time(tuple<u8, u8, u8, u32>), // (hour, minute, second, nanosecond)
+      /// Date-time types are always treated as UTC (without timezone info).
+      /// The instant is represented as a (year, month, day, hour, minute, second, nanosecond) tuple.
+      datetime(tuple<s32, u8, u8, u8, u8, u8, u32>),
+      /// Unix timestamp (seconds since epoch)
+      timestamp(s64),
+      uuid(string),
+      jsonb(list<u8>),
+      decimal(string), // base 10
+      range-int32(tuple<option<tuple<s32, range-bound-kind>>, option<tuple<s32, range-bound-kind>>>),
+      range-int64(tuple<option<tuple<s64, range-bound-kind>>, option<tuple<s64, range-bound-kind>>>),
+      range-decimal(tuple<option<tuple<string, range-bound-kind>>, option<tuple<string, range-bound-kind>>>),
+      array-int32(list<option<s32>>),
+      array-int64(list<option<s64>>),
+      array-decimal(list<option<string>>),
+      array-str(list<option<string>>),
+      interval(interval),
+      db-null,
+  }
+
+  record interval {
+    micros: s64,
+    days: s32,
+    months: s32,
+  }
+
+  /// A database column
+  record column {
+      name: string,
+      data-type: db-data-type,
+  }
+
+  /// A database row
+  type row = list<db-value>;
+
+  /// A set of database rows
+  record row-set {
+      columns: list<column>,
+      rows: list<row>,
+  }
+
+  /// For range types, indicates if each bound is inclusive or exclusive
+  enum range-bound-kind {
+    inclusive,
+    exclusive,
+  }
+
+  /// A connection to a postgres database.
+  resource connection {
+    /// Open a connection to the Postgres instance at `address`.
+    open: static func(address: string) -> result<connection, error>;
+
+    /// Query the database.
+    query: func(statement: string, params: list<parameter-value>) -> result<row-set, error>;
+
+    /// Execute command to the database.
+    execute: func(statement: string, params: list<parameter-value>) -> result<u64, error>;
+  }
+}

--- a/wit/deps/spin-sqlite@3.0.0/sqlite.wit
+++ b/wit/deps/spin-sqlite@3.0.0/sqlite.wit
@@ -1,0 +1,60 @@
+package spin:sqlite@3.0.0;
+
+interface sqlite {
+  /// A handle to an open sqlite instance
+  resource connection {
+    /// Open a connection to a named database instance.
+    ///
+    /// If `database` is "default", the default instance is opened.
+    ///
+    /// `error::no-such-database` will be raised if the `name` is not recognized.
+    open: static func(database: string) -> result<connection, error>;
+
+    /// Execute a statement returning back data if there is any
+    execute: func(statement: string, parameters: list<value>) -> result<query-result, error>;
+
+    /// The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+    /// there has not yet been an INSERT on the connection.
+    last-insert-rowid: func() -> s64;
+
+    /// The number of rows modified, inserted or deleted by the most recently completed
+    /// INSERT, UPDATE or DELETE statement on the connection.
+    changes: func() -> u64;
+  }
+
+  /// The set of errors which may be raised by functions in this interface
+  variant error {
+    /// The host does not recognize the database name requested.
+    no-such-database,
+    /// The requesting component does not have access to the specified database (which may or may not exist).
+    access-denied,
+    /// The provided connection is not valid
+    invalid-connection,
+    /// The database has reached its capacity
+    database-full,
+    /// Some implementation-specific error has occurred (e.g. I/O)
+    io(string)
+  }
+
+  /// A result of a query
+  record query-result {
+    /// The names of the columns retrieved in the query
+    columns: list<string>,
+    /// the row results each containing the values for all the columns for a given row
+    rows: list<row-result>,
+  }
+
+  /// A set of values for each of the columns in a query-result
+  record row-result {
+    values: list<value>
+  }
+
+  /// A single column's result from a database query
+  variant value {
+    integer(s64),
+    real(f64),
+    text(string),
+    blob(list<u8>),
+    null
+  }
+}

--- a/wit/deps/spin@3.0.0/world.wit
+++ b/wit/deps/spin@3.0.0/world.wit
@@ -1,4 +1,4 @@
-package spin:up@3.4.0;
+package fermyon:spin@3.0.0;
 
 /// The full world of a guest targeting an http-trigger
 world http-trigger {
@@ -11,7 +11,5 @@ world platform {
   include fermyon:spin/platform@2.0.0;
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:postgres/postgres@3.0.0;
-  import spin:postgres/postgres@4.0.0;
-  import spin:sqlite/sqlite@3.0.0;
   import wasi:config/store@0.2.0-draft-2024-09-27;
 }

--- a/wit/deps/spin@3.2.0/world.wit
+++ b/wit/deps/spin@3.2.0/world.wit
@@ -1,4 +1,4 @@
-package spin:up@3.4.0;
+package spin:up@3.2.0;
 
 /// The full world of a guest targeting an http-trigger
 world http-trigger {
@@ -11,7 +11,6 @@ world platform {
   include fermyon:spin/platform@2.0.0;
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:postgres/postgres@3.0.0;
-  import spin:postgres/postgres@4.0.0;
   import spin:sqlite/sqlite@3.0.0;
   import wasi:config/store@0.2.0-draft-2024-09-27;
 }


### PR DESCRIPTION
Fixes #79 and #80 

Draft for now because:

* ~Make deps opt-out, and make new code appropriately conditional:~
  * New deps: uuid, rust-decimal, postgres-range
  * Condition new code: serde, serde-json
* ~Figure out a solution for decoding `NUMERICRANGE`~ It's a horrible solution. But here we are
* Possibly reorganise the file as it's getting a bit ginormous
* ~Testing~ units, and example works on my machine
* ~Examples~ I did one for ranges which are the trap, can do more if suitably motivated
* ~Check documentation~
* ~Document workaround for range query grammar ambiguity~ https://github.com/spinframework/spin-docs/pull/119
