### PR TITLE
Dispatch release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,17 @@ jobs:
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  dispatch-rust-sdk-release:
+    name: Dispatch rust-sdk-release event to spinframework/spin
+    needs: crates
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'spinframework' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SPIN_REPO_PAT }}
+          repository: spinframework/spin
+          event-type: rust-sdk-release
+          client-payload: '{"version": "${{ github.ref_name }}"}'

--- a/release-process.md
+++ b/release-process.md
@@ -22,6 +22,6 @@ To cut a new release, you will need to do the following:
     git push origin v3.1.0
     ```
 
-6. Pushing the tag upstream will trigger the [release action](https://github.com/spinframework/spin-rust-sdk/actions/workflows/release.yml) which publishes the crates in this workspace to `crates.io`
+6. Pushing the tag upstream will trigger the [release action](https://github.com/spinframework/spin-rust-sdk/actions/workflows/release.yml) which publishes the crates in this workspace to `crates.io` and dispatches an `rust-sdk-release` event to the `spinframework/spin` repository. This event will trigger an action that updates the rust template's sdk dependency.
 
 7. If applicable, create PR(s) or coordinate [documentation](https://github.com/spinframework/spin-docs) needs, e.g. for new features or updated functionality.


### PR DESCRIPTION
Dispatches a release event to spin that will trigger an action that updates the `spin-sdk` dependency contained in the rust templates.